### PR TITLE
fix(ui): properly size editor containers [#140885285]

### DIFF
--- a/src/containers/App/App.js
+++ b/src/containers/App/App.js
@@ -31,9 +31,7 @@ class AppContainer extends Component {
 
     return (
       <Provider store={store}>
-        <div style={{ height: '100%' }}>
-          <Router history={browserHistory} children={routes} />
-        </div>
+        <Router history={browserHistory} children={routes} />
       </Provider>
     )
   }

--- a/src/layouts/CoreLayout/CoreLayout.js
+++ b/src/layouts/CoreLayout/CoreLayout.js
@@ -4,7 +4,7 @@ import classes from './CoreLayout.scss'
 import '../../styles/core.scss'
 
 export const CoreLayout = ({ children }) => (
-  <section class="core">
+  <section className={classes.coreLayout}>
     <Navbar />
     <section className={classes.mainContainer}>
       {children}

--- a/src/layouts/CoreLayout/CoreLayout.js
+++ b/src/layouts/CoreLayout/CoreLayout.js
@@ -4,12 +4,12 @@ import classes from './CoreLayout.scss'
 import '../../styles/core.scss'
 
 export const CoreLayout = ({ children }) => (
-  <div>
+  <section class="core">
     <Navbar />
-    <div className={classes.mainContainer}>
+    <section className={classes.mainContainer}>
       {children}
-    </div>
-  </div>
+    </section>
+  </section>
 )
 
 CoreLayout.propTypes = {

--- a/src/layouts/CoreLayout/CoreLayout.scss
+++ b/src/layouts/CoreLayout/CoreLayout.scss
@@ -1,2 +1,11 @@
 .mainContainer {
 }
+section:first-child {
+  display: flex;
+  flex-flow: column nowrap;
+}
+section:first-child,
+section:first-child > section {
+  height: 100%;
+  position: relative;
+}

--- a/src/layouts/CoreLayout/CoreLayout.scss
+++ b/src/layouts/CoreLayout/CoreLayout.scss
@@ -1,11 +1,10 @@
 .mainContainer {
+  position: relative;
 }
-section:first-child {
+
+.coreLayout,
+.mainContainer {
   display: flex;
   flex-flow: column nowrap;
-}
-section:first-child,
-section:first-child > section {
   height: 100%;
-  position: relative;
 }

--- a/src/routes/Projects/routes/Project/containers/SideBar/SideBar.scss
+++ b/src/routes/Projects/routes/Project/containers/SideBar/SideBar.scss
@@ -37,7 +37,8 @@ a {
   display: flex;
   flex-direction: row;
   justify-content: space-around;
-  padding: 0 10px 40px 10px;
+  padding: 20px 10px 0 10px;
+  margin-bottom: 10px;
   @media screen and (max-width: 700px){
     padding: 0 10px 5px 10px;
   }

--- a/tests/layouts/CoreLayout.spec.js
+++ b/tests/layouts/CoreLayout.spec.js
@@ -27,7 +27,7 @@ describe('(Layout) Core', function () {
     _component = shallowRenderWithProps(_props)
   })
 
-  it('Should render as a <div>.', function () {
-    expect(_component.type).to.equal('div')
+  it('Should render as a <section>.', function () {
+    expect(_component.type).to.equal('section')
   })
 })


### PR DESCRIPTION
### Summary of Changes

- fix root container sizing
- change root containers to `<section>` (from `<div>`)
- reduce SideBar button margins/paddings

### Screenshots

**Before**

<img width="600" alt="screen shot 2017-03-10 at 12 02 22 am" src="https://cloud.githubusercontent.com/assets/1915925/23784016/1331cd6c-0525-11e7-8dd5-670c0fc682af.png">

**After**

<img width="600" alt="screen shot 2017-03-10 at 12 02 07 am" src="https://cloud.githubusercontent.com/assets/1915925/23784011/0d2fee76-0525-11e7-939d-519a39557301.png">

