### PR TITLE
fix(readme): Travis build shield URL [#141478191]

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ Special thanks to @davezuko for creating [react-redux-starter-kit](https://githu
 
 [release-image]: https://img.shields.io/github/release/KyperTech/devshare-site.svg?style=flat-square
 [release-url]: https://github.com/KyperTech/devshare-site/releases
-[travis-image]: https://img.shields.io/travis/KyperTech/devshare-site/master.svg?style=flat-square
-[travis-url]: https://travis-ci.org/KyperTech/devshare-site
+[travis-image]: https://img.shields.io/travis/prescottprue/devshare-site/master.svg?style=flat-square
+[travis-url]: https://travis-ci.org/prescottprue/devshare-site
 [daviddm-image]: https://img.shields.io/david/KyperTech/devshare-site.svg?style=flat-square
 [daviddm-url]: https://david-dm.org/KyperTech/devshare-site
 [license-image]: https://img.shields.io/npm/l/devshare-site.svg?style=flat-square


### PR DESCRIPTION
### Summary of Changes

- fix "build" shield image URLs in README to point to the correct TravisCI project

**Before:**

<img width="150" src="https://cloud.githubusercontent.com/assets/1915925/23790328/3c697404-0544-11e7-97ae-7eac73181b7f.png"/>

**After:**

<img width="150" src="https://cloud.githubusercontent.com/assets/1915925/23790333/4747f80a-0544-11e7-96a5-d0df4164d2c9.png"/>
