### PR TITLE
fix(project-sharing-dialog): usernames in project sharing dialog

### DIFF
--- a/src/components/SharingDialog/SharingDialog.js
+++ b/src/components/SharingDialog/SharingDialog.js
@@ -79,8 +79,8 @@ export default class SharingDialog extends Component {
     const { collaborators, matchingUsers, searchText } = this.state
 
     const collabsList = collaborators
-      ? collaborators.map(({ image, username }, i) =>
-        <div key={`${project.name}-Collab-${i}`} className={classes['container']}>
+      ? collaborators.map(({ image, username }, i) => (
+        <div key={`${project.name}-Collab-${i}`} className={classes.container}>
           <ListItem
             leftAvatar={
               <Avatar
@@ -99,7 +99,7 @@ export default class SharingDialog extends Component {
             secondaryText='Read, Write'
           />
         </div>
-      )
+      ))
       : null
 
     const actions = [
@@ -123,14 +123,14 @@ export default class SharingDialog extends Component {
         title='Sharing'
         actions={actions}
         modal={false}
-        bodyClassName={classes['body']}
-        titleClassName={classes['title']}
-        contentClassName={classes['container']}
+        bodyClassName={classes.body}
+        titleClassName={classes.title}
+        contentClassName={classes.container}
       >
         {
           error
           ? (
-            <div className={classes['error']}>
+            <div className={classes.error}>
               <span>{error}</span>
             </div>
           )
@@ -151,7 +151,7 @@ export default class SharingDialog extends Component {
         }
         <div className={classes['search-container']}>
           <AutoComplete
-            className={classes['search']}
+            className={classes.search}
             hintText='Search users to add'
             floatingLabelText='Search users to add'
             fullWidth

--- a/src/routes/Projects/containers/ProjectsContainer.js
+++ b/src/routes/Projects/containers/ProjectsContainer.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react'
-import { toArray } from 'lodash'
+import { toArray, map } from 'lodash'
 
 // Components
 import ProjectTile from '../components/ProjectTile/ProjectTile'
@@ -38,7 +38,7 @@ const { pathToJS, dataToJS, isLoaded, isEmpty } = helpers
     auth: pathToJS(devshare, 'auth')
   })
 )
-export class Projects extends Component {
+export default class Projects extends Component {
 
   static contextTypes = {
     router: React.PropTypes.object.isRequired
@@ -108,24 +108,22 @@ export class Projects extends Component {
     // User has no projects and doesn't match logged in user
     if (isEmpty(projects) && account && username !== account.username) {
       return (
-        <div className={classes['container']}>
+        <div className={classes.container}>
           <div>This user has no projects</div>
         </div>
       )
     }
 
-    const projectsList = projects.map((project, i) =>
-      (
-        <ProjectTile
-          key={`${project.name}-Collab-${i}`}
-          project={project}
-          onCollabClick={this.collabClick}
-          onAddCollabClick={() => this.toggleModal('addCollab', project)}
-          onSelect={this.openProject}
-          onDelete={this.deleteProject}
+    const projectsList = map(projects, (project, i) => (
+      <ProjectTile
+        key={`Project-${i}`}
+        project={project}
+        onCollabClick={this.collabClick}
+        onAddCollabClick={() => this.toggleModal('addCollab', project)}
+        onSelect={this.openProject}
+        onDelete={this.deleteProject}
       />
-      )
-    )
+    ))
 
     // If username doesn't match route then hide add project tile
     if (account && account.username === username) {
@@ -138,7 +136,7 @@ export class Projects extends Component {
     }
 
     return (
-      <div className={classes['container']}>
+      <div className={classes.container}>
         {
           addCollabModal
           ? (
@@ -162,11 +160,10 @@ export class Projects extends Component {
             />
           ) : null
         }
-        <div className={classes['tiles']}>
+        <div className={classes.tiles}>
           {projectsList}
         </div>
       </div>
     )
   }
 }
-export default Projects

--- a/src/routes/Projects/routes/Project/containers/Project/Project.js
+++ b/src/routes/Projects/routes/Project/containers/Project/Project.js
@@ -16,15 +16,27 @@ const { isLoaded, dataToJS } = helpers
   ({ params }) =>
     ([
       `projects/${params.username}`,
-      `projects/${params.username}/${params.projectname}`
+      `projects/${params.username}/${params.projectname}`,
+      // TODO: Use population instead of loading whole usernames list
+      'usernames'
+      // `projects/${params.username}#populate=collaborators:users`,
     ])
 )
 @connect(
   // Map state to props
-  ({ devshare }, { params }) => ({
-    projects: toArray(dataToJS(devshare, `projects/${params.username}`)),
-    project: dataToJS(devshare, `projects/${params.username}/${params.projectname}`)
-  })
+  ({ devshare }, { params }) => {
+    const project = dataToJS(devshare, `projects/${params.username}/${params.projectname}`)
+    // TODO: Replace this with population
+    if (project.collaborators && dataToJS(devshare, 'usernames')) {
+      project.collaborators = project.collaborators.map(id => ({
+        username: dataToJS(devshare, 'usernames')[id]
+      }))
+    }
+    return {
+      projects: toArray(dataToJS(devshare, `projects/${params.username}`)),
+      project
+    }
+  }
 )
 export default class Project extends Component {
 


### PR DESCRIPTION
When within a project, usernames were not being displayed within the sharing dialog
#### What's this PR do?
* usernames were now displayed within the sharing dialog when in a project

#### What are the important parts of the code?
* `src/routes/Projects/routes/Project/containers/Project/Project.js`

#### Is any other information necessary to understand this?
* Project was not populated within Project container
* This should be done with population in the future

#### What are the relevant tickets? (Please add `closes`, `refs`, etc)
* [#142008369](https://www.pivotaltracker.com/story/show/142008369)

#### Screenshots (if appropriate)
Before:
![devshare](https://cloud.githubusercontent.com/assets/2992224/24078876/aae4cb2e-0c36-11e7-94a8-69aef8762b75.png)

After:
![screen shot 2017-03-18 at 11 57 55 pm](https://cloud.githubusercontent.com/assets/2992224/24078878/be33952a-0c36-11e7-83e3-53a748435b3c.png)

